### PR TITLE
add API for other mods to use, add Mineclone2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ You punch a gold block that's next to Mese to teleport 100 meters in the
 direction that the Mese is located relative to the gold block. Each
 additional Mese added in a straight line adds an additional 100 meters.
 You can also add Mese to multiple sides in such a way to go in diagonal
-directions! However, Mese on opposing sides cancel each other. Thanks to
-oscar14 for the Gold-Mese-Transport idea!
+directions! However, Mese on opposing sides cancel each other.
+
+Sneak-punching the gold block will allow it to be dug normally.
 
 If Mineclone2 is installed, this mod will instead use gold blocks and Redstone blocks for teleportation.
 
@@ -18,10 +19,18 @@ If neither of these mods are is not installed, another mod will need to use mese
 
 ``meseport.register_actionblock(node_name)`` - A method that sets a particular node type to trigger a meseport teleport when punched. When the default mod is installed it will automatically be called with ``meseport.register_actionblock("default:goldblock")``.
 
-``meseport.nodepowers`` - A table that determines how far an adjacent node of a particular type will send the puncher. For example, when the default mod is installed this table will be:
+``meseport.unregister_actionblock(node_name)`` - The opposite of the above, unregisters a particular node type and restores its old behaviour.
+
+``meseport.register_nodepower(node_name, power_level)`` - Determines how far an adjacent node of a particular type will send the puncher. Setting a power_level of ``nil`` or ``false`` will disable this node's use with this mod. Setting it to 0 means it can still be part of the chain of nodes that determine the actionblock's teleport range but won't contribute to it.
+
+``meseport.nodepowers`` - The table storing registered nodepowers. For example, when the default mod is installed this table will be:
 
 	{
 		["default:mese"] = 100
 	}
 
+Use ``meseport.register_nodepower`` to modify the values here.
+
 ### License: CC0
+
+Thanks to oscar14 for the Gold-Mese-Transport idea!

--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 ### A mod for [Minetest](http://www.minetest.net)
 
-This mod allows you to teleport by means of Mese and Gold structures.
+When used with the "default" mod, this mod allows you to teleport by means of Mese and Gold structures.
 You punch a gold block that's next to Mese to teleport 100 meters in the
 direction that the Mese is located relative to the gold block. Each
 additional Mese added in a straight line adds an additional 100 meters.
 You can also add Mese to multiple sides in such a way to go in diagonal
 directions! However, Mese on opposing sides cancel each other. Thanks to
 oscar14 for the Gold-Mese-Transport idea!
+
+If the default mod is not installed, another mod will need to use meseport's API to set what nodes it uses.
+
+## API
+
+``meseport.register_actionblock(node_name)`` - A method that sets a particular node type to trigger a meseport teleport when punched. When the default mod is installed it will automatically be called with ``meseport.register_actionblock("default:goldblock")``.
+
+``meseport.nodepowers`` - A table that determines how far an adjacent node of a particular type will send the puncher. For example, when the default mod is installed this table will be:
+
+	{
+		["default:mese"] = 100
+	}
 
 ### License: CC0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ You can also add Mese to multiple sides in such a way to go in diagonal
 directions! However, Mese on opposing sides cancel each other. Thanks to
 oscar14 for the Gold-Mese-Transport idea!
 
-If the default mod is not installed, another mod will need to use meseport's API to set what nodes it uses.
+If Mineclone2 is installed, this mod will instead use gold blocks and Redstone blocks for teleportation.
+
+If neither of these mods are is not installed, another mod will need to use meseport's API to set what nodes it uses.
 
 ## API
 

--- a/init.lua
+++ b/init.lua
@@ -51,3 +51,11 @@ if minetest.get_modpath("default") then
 	meseport.nodepowers["default:mese"] = 100
 	meseport.register_actionblock("default:goldblock")
 end
+
+if minetest.get_modpath("mcl_core")
+	and minetest.get_modpath("mesecons_torch")
+	and minetest.registered_nodes["mesecons_torch:redstoneblock"] then
+	
+	meseport.register_actionblock("mcl_core:goldblock")
+	meseport.nodepowers["mesecons_torch:redstoneblock"] = 100
+end

--- a/init.lua
+++ b/init.lua
@@ -1,43 +1,53 @@
 meseport = {} -- Add a table so other mods are aware of it.
 
-local ActionBlockType = "default:goldblock"
-local NodePowers = {["default:mese"] = 100}
+local PunchDebounces = {}
 local AxisDirections = {'x', 'y', 'z'}
 local Polarities = {-1, 1}
 
-local on_punch_old = ItemStack(ActionBlockType):get_definition().on_punch -- Added to avoid conflicts with other mods.
-local PunchDebounces = {}
+meseport.nodepowers = {}
+local NodePowers = meseport.nodepowers
 
-minetest.override_item(ActionBlockType, {
-	on_punch = function(pos, node, puncher, pointed_thing)
-		if not PunchDebounces[puncher] then
-			local power = {x = 0, y = 0, z = 0}
-			local readPos = {x = pos.x, y = pos.y, z = pos.z}
-			
-			-- Figure out the relative position to teleport.
-			for _, axis in ipairs(AxisDirections) do
-				for _, polarity in ipairs(Polarities) do
-					local readNode = nil
-					repeat
-						readPos[axis] = readPos[axis] + polarity
-						readNode = minetest.get_node(readPos).name
-						power[axis] = power[axis] + (NodePowers[readNode] or 0) * polarity
-					until NodePowers[readNode] == nil
-					readPos[axis] = pos[axis]
+meseport.register_actionblock = function(ActionBlockType)
+	local action_block_def = minetest.registered_nodes[ActionBlockType]
+	assert(action_block_def ~= nil)
+	local on_punch_old = action_block_def.on_punch -- Added to avoid conflicts with other mods.
+	
+	minetest.override_item(ActionBlockType, {
+		on_punch = function(pos, node, puncher, pointed_thing)
+			if not PunchDebounces[puncher] then
+				local power = {x = 0, y = 0, z = 0}
+				local readPos = {x = pos.x, y = pos.y, z = pos.z}
+				
+				-- Figure out the relative position to teleport.
+				for _, axis in ipairs(AxisDirections) do
+					for _, polarity in ipairs(Polarities) do
+						local readNode = nil
+						repeat
+							readPos[axis] = readPos[axis] + polarity
+							readNode = minetest.get_node(readPos).name
+							power[axis] = power[axis] + (NodePowers[readNode] or 0) * polarity
+						until NodePowers[readNode] == nil
+						readPos[axis] = pos[axis]
+					end
+				end
+				
+				-- Teleport the player
+				if power.x ~= 0 or power.y ~= 0 or power.z ~= 0 then
+					local puncherPos = puncher:get_pos()
+					puncher:set_pos({x = puncherPos.x + power.x, y = puncherPos.y + power.y, z = puncherPos.z + power.z})
+					PunchDebounces[puncher] = true
+					minetest.after(0.5, function(...)
+						PunchDebounces[puncher] = nil
+					end)
 				end
 			end
-			
-			-- Teleport the player
-			if power.x ~= 0 or power.y ~= 0 or power.z ~= 0 then
-				local puncherPos = puncher:getpos()
-				puncher:setpos({x = puncherPos.x + power.x, y = puncherPos.y + power.y, z = puncherPos.z + power.z})
-				PunchDebounces[puncher] = true
-				minetest.after(0.5, function(...)
-					PunchDebounces[puncher] = nil
-				end)
-			end
-		end
+	
+			return on_punch_old(pos, node, puncher, pointed_thing) -- Added to avoid conflicts with other mods.
+		end,
+	})
+end
 
-		return on_punch_old(pos, node, puncher, pointed_thing) -- Added to avoid conflicts with other mods.
-	end,
-})
+if minetest.get_modpath("default") then
+	meseport.nodepowers["default:mese"] = 100
+	meseport.register_actionblock("default:goldblock")
+end

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,2 @@
+name = meseport
+optional_depends = default

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = meseport
-optional_depends = default
+optional_depends = default, mcl_core, mesecons_torch


### PR DESCRIPTION
Couple of changes in here that are meant to open up this mod's range of uses without changing its default behaviour. First I updated a few deprecated functions (getpos and setpos) and then added an API for registering actionblocks and nodepowers. Then I added Mineclone2 game compatibility - instead of mese blocks it uses redstone blocks when run with that game.

The only change I made to existing functionality was to add the option for the player to hold down the "sneak" key when punching to dig the block normally. This felt like a reasonable option to give the player since they could do this by digging away the mese blocks first, this way they can skip the extra digging.

Hope these are good, I was thinking I'd like to use this form of teleportation but with different blocks and this API would let me fiddle with those freely without having to custom-fork this mod to accomplish it.